### PR TITLE
Supports mtl for obj files.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ clap-verbosity-flag = "2"
 regex = "1"
 glob = "0.3"
 meshx = "0.6"
+vtkio = { version = "0.6" }
 byteorder = "1"
 indicatif = { version = "0.17", features = ["rayon"] }
 console = "0.15"


### PR DESCRIPTION
### Summary

 - Adds support for mtl files when loading wavefront files.

### Implementation details

 - Meshx was already supporting mtls files but we weren't loading them when using the API. This PR simply calls the load_mtls method necessary to have them loaded.

